### PR TITLE
quickstart docs update, add instance path to gitignore #26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 classes/
 fork.properties
 
+### Local AEM instance
+.instance/
+
 ### Java template
 *.class
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Documentation for:
 1. Fork project using command:
 
     ```bash
-    git clone git@github.com:Cognifide/gradle-aem-single.git && cd gradle-aem-single && ./gradlew fork
+    git clone https://github.com/Cognifide/gradle-aem-single.git && cd gradle-aem-single && ./gradlew fork
     ```
 
     and specify properties:


### PR DESCRIPTION
- Update fork command from SSH to HTTP in quickstart docs.
- Add `.instance` path to gitignore for disallow GIT to try add AEM into repository.